### PR TITLE
Allow requirejs compatiblity.

### DIFF
--- a/lib/weld.js
+++ b/lib/weld.js
@@ -26,6 +26,7 @@
   
   var inputRegex = /input|select|textarea|option|button/i;
   var imageRegex = /img/i;
+  var anchorRegex = /^a$/i;
   var depth = 0;  // The current depth of the traversal, used for debugging.
   var successIndicator = nodejs ? (color.green + ' ✓' + color.gray) : ' Success';
   var failureIndicator = nodejs ? (color.red + ' ✗' + color.gray) : ' Fail';
@@ -292,6 +293,11 @@
             if (imageRegex.test(nodeName)) {
               return 'image';
             }
+
+            if (anchorRegex.test(nodeName)) {
+              return 'anchor';
+            }
+
           }
         }
       },
@@ -337,6 +343,10 @@
         }
         else if (type === 'image') {
           element.setAttribute('src', value);
+          res = true;
+        }
+        else if (type === 'anchor') {
+          element.setAttribute('href', value);
           res = true;
         }
         else { // simple text assignment.


### PR DESCRIPTION
I added a couple checks for define.amd and a return statement that returns weld.

I do not know if this quick hack works with all AMD (http://wiki.commonjs.org/wiki/Modules/AsynchronousDefinition) compatible loaders, as I have only tested it in the browser with requirejs.
