### PR TITLE
Allow requirejs compatiblity.

### DIFF
--- a/lib/weld.js
+++ b/lib/weld.js
@@ -6,7 +6,7 @@
   var logger = (typeof console === 'undefined') ? { log : function(){} } : console;
   var nodejs = false;
 
-  if (typeof require !== 'undefined') {
+  if (typeof require !== 'undefined' && !define.amd) {
     var tty = require('tty');
     if (tty.isatty && tty.isatty(0)) {
       nodejs = true;
@@ -407,3 +407,6 @@
 
 })((typeof exports === "undefined") ? window : exports);
 
+if (typeof define !== "undefined" && define.amd) {
+    define('weld',[], function() {return window.weld });
+}


### PR DESCRIPTION
I added a couple checks for define.amd and a return statement that returns weld.

I do not know if this quick hack works with all AMD (http://wiki.commonjs.org/wiki/Modules/AsynchronousDefinition) compatible loaders, as I have only tested it in the browser with requirejs.

(sorry about the previous pull request, this should be fixed)
