### PR TITLE
update href properties of anchors

### DIFF
--- a/lib/weld.js
+++ b/lib/weld.js
@@ -26,6 +26,7 @@
   
   var inputRegex = /input|select|textarea|option|button/i;
   var imageRegex = /img/i;
+  var anchorRegex = /^a$/i;
   var depth = 0;  // The current depth of the traversal, used for debugging.
   var successIndicator = nodejs ? (color.green + ' ✓' + color.gray) : ' Success';
   var failureIndicator = nodejs ? (color.red + ' ✗' + color.gray) : ' Fail';
@@ -292,6 +293,11 @@
             if (imageRegex.test(nodeName)) {
               return 'image';
             }
+
+            if (anchorRegex.test(nodeName)) {
+              return 'anchor';
+            }
+
           }
         }
       },
@@ -337,6 +343,10 @@
         }
         else if (type === 'image') {
           element.setAttribute('src', value);
+          res = true;
+        }
+        else if (type === 'anchor') {
+          element.setAttribute('href', value);
           res = true;
         }
         else { // simple text assignment.


### PR DESCRIPTION
When using weld, it seems natural that if you're welding data to an anchor element, that you'd want to be able to update the target of a link when welding data to it.  This patch is a modification that checks if the matched element is an achor, and if so, updates the href property.

This is a backward-incompatible change, and any uses of weld that currently use weld to update the text of an anchor element will break.  

If the desired behavior is to update the text of an achor, using a span element inside an achor element allows you to change both the link text and the target.
