### PR TITLE
Added ability to set value by returning String from map function

### DIFF
--- a/lib/weld.js
+++ b/lib/weld.js
@@ -346,7 +346,9 @@
       },
       set : function set(parent, element, key, value) {
 
-        if(ops.map && ops.map(parent, element, key, value) === false) {
+        //capture the result of the map call and use it to override value
+        var override = (ops.map) ? ops.map(parent, element, key, value) : null;
+        if(override !==null &&  override === false) {
           return false;
         }
 
@@ -380,7 +382,7 @@
           res = true;
         }
         else { // simple text assignment.
-          element.textContent = value;
+          element.textContent = typeof(override)=='string' ? override : value;
           res = true;
         }
         return res;

--- a/test/test.js
+++ b/test/test.js
@@ -269,7 +269,7 @@
         weld($(template)[0], [
           { where : 'world' }
         ], {
-          map : function(element, k, v) {
+          map : function(parent, element, k, v) {
             return false;
           }
         });
@@ -432,6 +432,52 @@
 
         test.done();
       })
+    },
+    "Test 19: Returning string from map replaces the value with the provided string" : function(test) {
+      getTemplate('null', function(window, weld, $) {
+
+        var template = $('<ul class="list"><li class="item">hello <span class="where">replace this</span><span class="other">other text</span></li></ul>');
+        $('#temp').append(template);
+
+        weld($(template)[0], [
+          {
+              where : 'do not display this',
+              other : 'stuff'
+          }
+        ], {
+          map : function(parent, element, k, v) {
+              if(k == 'where')
+              {
+                  return 'display this instead';
+              }
+            return true;
+          }
+        });
+
+        test.ok($('.where').text() === 'display this instead');
+        test.ok($('.other').text() === 'stuff');
+        test.done();
+
+      });
+    },
+    "Test 20: Returning true from map does not effect value" : function(test) {
+      getTemplate('null', function(window, weld, $) {
+
+        var template = $('<ul class="list"><li class="item">hello <span class="where">replace this</span></li></ul>');
+        $('#temp').append(template);
+
+        weld($(template)[0], [
+          { where : 'display this' }
+        ], {
+          map : function(parent, element, k, v) {
+            return true;
+          }
+        });
+
+        test.ok($('.where').text() === 'display this');
+        test.done();
+
+      });
     }
   };
 }((typeof module === "undefined") ? window : module.exports));


### PR DESCRIPTION
Returning a String from the map function will use the Sting as the
element text value.
Added tests and corrected some tests with outdated parameters to the
map function

Example:
weld($(template)[0], [
          {
              where : 'do not display this',
              other : 'stuff'
          }
        ], {
          map : function(parent, element, k, v) {
              if(k == 'where')
              {
                  return 'display this instead';
              }
            return true;
          }
        });