### PR TITLE
Textareas not having prefilled values when using weld to serve HTML from node.js & jsdom

### DIFF
--- a/lib/weld.js
+++ b/lib/weld.js
@@ -72,8 +72,9 @@
     white: '\033[1;37m'
   };
 
-  var inputRegex = /input|select|textarea|option|button/i;
+  var inputRegex = /input|select|option|button/i;
   var imageRegex = /img/i;
+  var textareaRegex = /textarea/i;
   var depth = 0;  // The current depth of the traversal, used for debugging.
   var successIndicator = nodejs ? (color.green + ' ✓' + color.gray) : ' Success';
   var failureIndicator = nodejs ? (color.red + ' ✗' + color.gray) : ' Fail';
@@ -329,6 +330,10 @@
             if (imageRegex.test(nodeName)) {
               return 'image';
             }
+
+            if (textareaRegex.test(nodeName)) {
+              return 'textarea';
+            }
           }
         }
       },
@@ -374,6 +379,14 @@
         }
         else if (type === 'image') {
           element.setAttribute('src', value);
+          res = true;
+        }
+        else if (type === 'textarea') {
+          element.textContent = value;
+          if (element.value !== value) {
+            // Here's looking at you Opera.
+            element.value = value;
+          }
           res = true;
         }
         else { // simple text assignment.


### PR DESCRIPTION
When serving textarea elements from node.js using weld and jsdom, I was getting the value as an attribute on the textarea instead of as text content. This attribute is ignored by browsers getting served html from node.js.

This commit changed handling of textarea to use .textContent instead of .value. Opera ignores the child text nodes resulting from using .textContent while the textarea isn't in the document tree.  To work around this, .value is still used for Opera.
